### PR TITLE
Provide strong API for WebViewActivity client code.

### DIFF
--- a/app/src/main/java/org/andydyer/androidtestdemo/ui/WebViewActivity.java
+++ b/app/src/main/java/org/andydyer/androidtestdemo/ui/WebViewActivity.java
@@ -1,5 +1,7 @@
 package org.andydyer.androidtestdemo.ui;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.view.MenuItem;
@@ -10,14 +12,18 @@ import org.andydyer.androidtestdemo.R;
 
 import butterknife.ButterKnife;
 import butterknife.InjectView;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 /**
  * Created by andy on 8/23/14.
  */
 public class WebViewActivity extends ActionBarActivity {
 
-    public static final String EXTRA_URL = "url";
-    public static final String EXTRA_TITLE = "title";
+    private static final String EXTRA_URL = "url";
+    private static final String EXTRA_TITLE = "title";
 
     @InjectView(R.id.webview) WebView webview;
 
@@ -49,6 +55,30 @@ public class WebViewActivity extends ActionBarActivity {
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
+        }
+    }
+
+    public static IntentBuilder intent(Context context) {
+        return new IntentBuilder(context);
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Setter
+    @Accessors(chain = true, fluent = true)
+    public static final class IntentBuilder {
+
+        private final Context context;
+        private String url;
+        private String title;
+
+        public void start() {
+            if (url == null || title == null) {
+                throw new IllegalStateException("Url and Title must not be null.");
+            }
+            Intent intent = new Intent(context, WebViewActivity.class);
+            intent.putExtra(EXTRA_URL, url);
+            intent.putExtra(EXTRA_TITLE, title);
+            context.startActivity(intent);
         }
     }
 }

--- a/app/src/main/java/org/andydyer/androidtestdemo/ui/fragments/EventListFragment.java
+++ b/app/src/main/java/org/andydyer/androidtestdemo/ui/fragments/EventListFragment.java
@@ -1,6 +1,5 @@
 package org.andydyer.androidtestdemo.ui.fragments;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -147,9 +146,9 @@ public class EventListFragment extends Fragment implements Callback<Events> {
 
     private void launchWebViewActivity(String path) {
         String url = String.format("http://github.com/%s", path);
-        Intent intent = new Intent(getActivity(), WebViewActivity.class);
-        intent.putExtra(WebViewActivity.EXTRA_TITLE, path);
-        intent.putExtra(WebViewActivity.EXTRA_URL, url);
-        startActivity(intent);
+        WebViewActivity.intent(getActivity())
+                .title(path)
+                .url(url)
+                .start();
     }
 }


### PR DESCRIPTION
One thing I wanted to show you how I use Lombok. This is far from ideal because of the amount of code added, but about that later.

The postive side is how it simplifies use of class. `static final String EXTRA_URL = "url";` becomes `private` and `WebViewActivity.intent...start()` is so easy to write with autocompletion.

A better way instead of using `@RequiredArgsConstructor` + `@Setter` + `@Accessors` would be to have an annotation `@Extra` for private non-static fields and have all this code generated, together with parts I didn't touch: `getIntent().getStringExtra(EXTRA_URL)`.
